### PR TITLE
add Collections to Gateway Transaction so the discovery service and s…

### DIFF
--- a/pkg/gateway/transaction_test.go
+++ b/pkg/gateway/transaction_test.go
@@ -54,6 +54,7 @@ func TestTransactionOptions(t *testing.T) {
 		"txn1",
 		WithTransient(transient),
 		WithEndorsingPeers("peer1"),
+		WithCollections("_implicit_org_org1"),
 	)
 
 	if err != nil {
@@ -68,6 +69,11 @@ func TestTransactionOptions(t *testing.T) {
 	endorsers := txn.endorsingPeers
 	if endorsers[0] != "peer1" {
 		t.Fatalf("Incorrect endorsing peer: %s", endorsers[0])
+	}
+
+	collections := txn.collections
+	if collections[0] != "_implicit_org_org1" {
+		t.Fatalf("Incorrect collection: %s", collections[0])
 	}
 
 	txn.Evaluate("arg1", "arg2")


### PR DESCRIPTION
…elector can send the transaction to the correct endorsement peers (#170)

* add GetPeersOfOrg to Gateway Network to obtain available peers from an org.

Signed-off-by: Bram Dufour <britaj@bancolombia.com.co>

* Add comment to exported GetPeersOfOrg function in gateway Network

Signed-off-by: Bram Dufour <britaj@bancolombia.com.co>

* Add unit test to check if a peer is retrieved for an org.

Signed-off-by: Bram Dufour <britaj@bancolombia.com.co>

* Add collections to Transaction and set them in the InvocationChain's ChaincodeCall

Signed-off-by: Bram Dufour <britaj@bancolombia.com.co>